### PR TITLE
Add config options for brotli.compress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Change Log for `flask-compress`
+All notable changes to `flask-compress` will be documented in this file.
+
+## [Unreleased]
+### Added
+- The following parameters to control Brotli compression are now available: `COMPRESSION_BR_MODE`, `COMPRESSION_BR_QUALITY`, `COMPRESS_BR_WINDOW`, `COMPRESSION_BR_BLOCK`. [#10](https://github.com/colour-science/flask-compress/pull/10)
+
+### Changed
+- The default quality level for Brotli is now 6, which provides compression comparable to `gzip` at the default setting, while reducing the time required versus the Brotli default of 11.
+
+## [1.6.0] - 2020-10-05
+### Added
+- Support for multiple compression algorithms and quality factors [#7](https://github.com/colour-science/flask-compress/pull/7)
+
+### Changed
+- Modified default compression settings to use Brotli when available before `gzip`
+
+## [1.5.0] - 2020-05-09
+
+## [1.4.0] - 2017-01-04
+
+## [1.3.2] - 2016-09-28
+
+## [1.3.1] - 2016-09-21
+
+## [1.3.0] - 2015-10-08
+
+## [1.2.1] - 2015-06-02
+
+## [1.2.0] - 2015-03-27
+
+## [1.1.1] - 2015-03-24
+
+## [1.1.0] - 2015-02-16
+
+## [1.0.2] - 2014-04-19
+
+## [1.0.2] - 2014-04-19
+
+## [1.0.1] - 2014-03-04
+### Changed
+- Temporarily remove test for vary header until it is fixed.
+
+## [1.0.0] - 2013-10-28
+
+## [0.10.0] - 2013-08-15
+
+## [0.9.0] - 2013-08-14
+### Fixed
+- Fixed a runtime error when `direct_passthrough` is used.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ Within your Flask application's settings you can provide the following settings 
 | `COMPRESS_CACHE_BACKEND` | Specified the backend for storing the cached response data. | `None` |
 | `COMPRESS_REGISTER` | Specifies if compression should be automatically registered. | `True` |
 | `COMPRESS_ALGORITHM` | Supported compression algorithms. | `['br', 'gzip']` |
+| `COMPRESS_BR_MODE` | For Brotli, the compression mode. The options are 0, 1, or 2. These correspond to "generic", "text" (for UTF-8 input), and "font" (for WOFF 2.0). | `0` |
+| `COMPRESS_BR_QUALITY` | For Brotli, the desired compression level. Proivdes control over the speed/compression density tradeoff. Higher values provide better compression at the cost of compression time. Ranges from 0 to 11. | `4` |
+| `COMPRESS_BR_WINDOW` | For Brotli, this specifies the base-2 logarithm of the sliding window size. Ranges from 10 to 24. | `22` |
+| `COMPRESS_BR_BLOCK` | For Brotli, this provides the base-2 logarithm of the maximum input block size. If zero is provided, value will be determined based on the quality. Ranges from 16 to 24. | `0` |

--- a/flask_compress.py
+++ b/flask_compress.py
@@ -66,10 +66,10 @@ class Compress(object):
                                     'application/json',
                                     'application/javascript']),
             ('COMPRESS_LEVEL', 6),
-            ('COMPRESS_MODE', 0),
-            ('COMPRESS_QUALITY_LEVEL', 4),
-            ('COMPRESS_WINDOW_SIZE', 22),
-            ('COMPRESS_BLOCK_SIZE', 0),
+            ('COMPRESS_BR_MODE', 0),
+            ('COMPRESS_BR_QUALITY', 4),
+            ('COMPRESS_BR_WINDOW', 22),
+            ('COMPRESS_BR_BLOCK', 0),
             ('COMPRESS_MIN_SIZE', 500),
             ('COMPRESS_CACHE_KEY', None),
             ('COMPRESS_CACHE_BACKEND', None),
@@ -204,7 +204,7 @@ class Compress(object):
             return gzip_buffer.getvalue()
         elif algorithm == 'br':
             return brotli.compress(response.get_data(),
-                                   mode=app.config['COMPRESS_MODE'],
-                                   quality=app.config['COMPRESS_QUALITY_LEVEL'],
-                                   lgwin=app.config['COMPRESS_WINDOW_SIZE'],
-                                   lgblock=app.config['COMPRESS_BLOCK_SIZE'])
+                                   mode=app.config['COMPRESS_BR_MODE'],
+                                   quality=app.config['COMPRESS_BR_QUALITY'],
+                                   lgwin=app.config['COMPRESS_BR_WINDOW'],
+                                   lgblock=app.config['COMPRESS_BR_SIZE'])

--- a/flask_compress.py
+++ b/flask_compress.py
@@ -66,6 +66,10 @@ class Compress(object):
                                     'application/json',
                                     'application/javascript']),
             ('COMPRESS_LEVEL', 6),
+            ('COMPRESS_MODE', 0),
+            ('COMPRESS_QUALITY_LEVEL', 4),
+            ('COMPRESS_WINDOW_SIZE', 22),
+            ('COMPRESS_BLOCK_SIZE', 0),
             ('COMPRESS_MIN_SIZE', 500),
             ('COMPRESS_CACHE_KEY', None),
             ('COMPRESS_CACHE_BACKEND', None),
@@ -199,4 +203,8 @@ class Compress(object):
                 gzip_file.write(response.get_data())
             return gzip_buffer.getvalue()
         elif algorithm == 'br':
-            return brotli.compress(response.get_data())
+            return brotli.compress(response.get_data(),
+                                   mode=app.config['COMPRESS_MODE'],
+                                   quality=app.config['COMPRESS_QUALITY_LEVEL'],
+                                   lgwin=app.config['COMPRESS_WINDOW_SIZE'],
+                                   lgblock=app.config['COMPRESS_BLOCK_SIZE'])

--- a/flask_compress.py
+++ b/flask_compress.py
@@ -207,4 +207,4 @@ class Compress(object):
                                    mode=app.config['COMPRESS_BR_MODE'],
                                    quality=app.config['COMPRESS_BR_QUALITY'],
                                    lgwin=app.config['COMPRESS_BR_WINDOW'],
-                                   lgblock=app.config['COMPRESS_BR_SIZE'])
+                                   lgblock=app.config['COMPRESS_BR_BLOCK'])

--- a/tests/test_flask_compress.py
+++ b/tests/test_flask_compress.py
@@ -32,20 +32,20 @@ class DefaultsTest(unittest.TestCase):
         self.assertEqual(self.app.config['COMPRESS_ALGORITHM'], ['br', 'gzip'])
 
     def test_mode_default(self):
-        """ Tests COMPRESS_MODE default value is correctly set. """
-        self.assertEqual(self.app.config['COMPRESS_MODE'], 0)
+        """ Tests COMPRESS_BR_MODE default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_BR_MODE'], 0)
 
     def test_quality_level_default(self):
-        """ Tests COMPRESS_QUALITY_LEVEL default value is correctly set. """
-        self.assertEqual(self.app.config['COMPRESS_QUALITY_LEVEL'], 4)
+        """ Tests COMPRESS_BR_QUALITY default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_BR_QUALITY'], 4)
 
     def test_window_size_default(self):
-        """ Tests COMPRESS_WINDOW_SIZE default value is correctly set. """
-        self.assertEqual(self.app.config['COMPRESS_WINDOW_SIZE'], 22)
+        """ Tests COMPRESS_BR_WINDOW default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_BR_WINDOW'], 22)
 
     def test_block_size_default(self):
-        """ Tests COMPRESS_BLOCK_SIZE default value is correctly set. """
-        self.assertEqual(self.app.config['COMPRESS_BLOCK_SIZE'], 0)
+        """ Tests COMPRESS_BR_BLOCK default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_BR_BLOCK'], 0)
 
 class InitTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_flask_compress.py
+++ b/tests/test_flask_compress.py
@@ -31,6 +31,21 @@ class DefaultsTest(unittest.TestCase):
         """ Tests COMPRESS_ALGORITHM default value is correctly set. """
         self.assertEqual(self.app.config['COMPRESS_ALGORITHM'], ['br', 'gzip'])
 
+    def test_mode_default(self):
+        """ Tests COMPRESS_MODE default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_MODE'], 0)
+
+    def test_quality_level_default(self):
+        """ Tests COMPRESS_QUALITY_LEVEL default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_QUALITY_LEVEL'], 4)
+
+    def test_window_size_default(self):
+        """ Tests COMPRESS_WINDOW_SIZE default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_WINDOW_SIZE'], 22)
+
+    def test_block_size_default(self):
+        """ Tests COMPRESS_BLOCK_SIZE default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_BLOCK_SIZE'], 0)
 
 class InitTests(unittest.TestCase):
     def setUp(self):
@@ -116,6 +131,17 @@ class UrlTests(unittest.TestCase):
         response = client.options('/small/', headers=headers)
         self.assertEqual(response.status_code, 200)
 
+    def test_quality_level(self):
+        """ Tests COMPRESS_QUALITY_LEVEL correctly affects response data. """
+        self.app.config['COMPRESS_QUALITY_LEVEL'] = 4
+        response = self.client_get('/large/')
+        response4_size = len(response.data)
+
+        self.app.config['COMPRESS_QUALITY_LEVEL'] = 11
+        response = self.client_get('/large/')
+        response11_size = len(response.data)
+
+        self.assertNotEqual(response4_size, response11_size)
 
 class CompressionAlgoTests(unittest.TestCase):
     """

--- a/tests/test_flask_compress.py
+++ b/tests/test_flask_compress.py
@@ -132,13 +132,15 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_quality_level(self):
-        """ Tests COMPRESS_QUALITY_LEVEL correctly affects response data. """
-        self.app.config['COMPRESS_QUALITY_LEVEL'] = 4
-        response = self.client_get('/large/')
+        """ Tests that COMPRESS_BR_QUALITY correctly affects response data. """
+        self.app.config['COMPRESS_BR_QUALITY'] = 4
+        client = self.app.test_client()
+        response = client.get('/large/', headers=[('Accept-Encoding', 'br')])
         response4_size = len(response.data)
 
-        self.app.config['COMPRESS_QUALITY_LEVEL'] = 11
-        response = self.client_get('/large/')
+        self.app.config['COMPRESS_BR_QUALITY'] = 11
+        client = self.app.test_client()
+        response = client.get('/large/', headers=[('Accept-Encoding', 'br')])
         response11_size = len(response.data)
 
         self.assertNotEqual(response4_size, response11_size)


### PR DESCRIPTION
As of 48973cd260928c9daba6082d54ced63a0de825c9, `flask-compress` now uses Brotli by default when the browser supports it.

While options to specify `gzip` compression parameters are available, the default compression setting is used when `br` is accepted; a quality level of 11 provides excellent compression, but is much slower than the previous default `gzip` setting.

This PR proposes to add support for specifying options passed to `brotli.compress`, in case application developers wish to specify a less aggressive compression setting. A couple basic tests mimicing those already present for `gzip` are also included. 

Finally, the Brotli quality level default is changed to 4 from 11, which is a little more brisk (and comparable to the previous default, `gzip` level 6) when compressing on-the-fly.