### PR TITLE
Do not install top-level "tests" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Compress responses in your Flask app with gzip, deflate or brotli.',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
Fixes a regression in af2f16335279044e8baeab42e0b182d3e05861b4 that
causes "tests" to be installed as a top-level package to site-packages.