### PR TITLE
Exclude User Agents from compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,5 @@ Within your Flask application's settings you can provide the following settings 
 | `COMPRESS_CACHE_BACKEND` | Specified the backend for storing the cached response data. | `None` |
 | `COMPRESS_REGISTER` | Specifies if compression should be automatically registered. | `True` |
 | `COMPRESS_ALGORITHM` | Supported compression algorithms. | `['br', 'gzip', 'deflate']` |
+| `COMPRESS_EXCLUDE_UA` | Do not compress User Agents containing one of the strings in the list. | `[]` |
+| `COMPRESS_TRACE` | Log debug information. | `False` |


### PR DESCRIPTION
Some User Agent should be excluded from compression to avoid decoding issues.

For instance, Safari 11.1.2 included in Mac OS X 10.11.6 gives this status message: *Safari can't open the page*. The error is: *“cannot decode raw data” (NSURLErrorDomain:-1015)*. Its UA is: *"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"*

This browser can be excluded from compression by setting `app.config["COMPRESS_EXCLUDE_UA"] = ['Mac OS X 10']`.

Also, `app.config["COMPRESS_TRACE"] = True` enables to log the User Agent.
