### PR TITLE
added `COMPRESS_STREAMS` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sw[klmnop]
 # python
 *.py[co~]
+.python-version
 # Ignoring build dir
 /build
 /dist

--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ Within your Flask application's settings you can provide the following settings 
 | `COMPRESS_CACHE_BACKEND` | Specified the backend for storing the cached response data. | `None` |
 | `COMPRESS_REGISTER` | Specifies if compression should be automatically registered. | `True` |
 | `COMPRESS_ALGORITHM` | Supported compression algorithms. | `['br', 'gzip', 'deflate']` |
+| `COMPRESS_STREAMS` | Compress content streams. | `True` |

--- a/flask_compress/flask_compress.py
+++ b/flask_compress/flask_compress.py
@@ -77,6 +77,7 @@ class Compress(object):
             ('COMPRESS_CACHE_KEY', None),
             ('COMPRESS_CACHE_BACKEND', None),
             ('COMPRESS_REGISTER', True),
+            ('COMPRESS_STREAMS', True),
             ('COMPRESS_ALGORITHM', ['br', 'gzip', 'deflate']),
         ]
 
@@ -178,7 +179,7 @@ class Compress(object):
             response.mimetype not in app.config["COMPRESS_MIMETYPES"] or
             response.status_code < 200 or
             response.status_code >= 300 or
-            response.is_streamed or
+            (response.is_streamed and app.config["COMPRESS_STREAMS"] is False)or
             "Content-Encoding" in response.headers or
             (response.content_length is not None and
              response.content_length < app.config["COMPRESS_MIN_SIZE"])):

--- a/tests/test_flask_compress.py
+++ b/tests/test_flask_compress.py
@@ -51,6 +51,10 @@ class DefaultsTest(unittest.TestCase):
         """ Tests COMPRESS_BR_BLOCK default value is correctly set. """
         self.assertEqual(self.app.config['COMPRESS_BR_BLOCK'], 0)
 
+    def test_stream(self):
+        """ Tests COMPRESS_STREAMS default value is correctly set. """
+        self.assertEqual(self.app.config['COMPRESS_STREAMS'], True)
+
 class InitTests(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
@@ -353,12 +357,11 @@ class StreamTests(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
         self.app.testing = True
+        self.app.config["COMPRESS_STREAMS"] = False
 
         self.file_path = os.path.join(os.getcwd(), 'tests', 'templates',
                                       'large.html')
         self.file_size = os.path.getsize(self.file_path)
-
-        Compress(self.app)
 
         @self.app.route('/stream/large')
         def stream():
@@ -370,6 +373,7 @@ class StreamTests(unittest.TestCase):
 
     def test_no_compression_stream(self):
         """ Tests compression is skipped when response is streamed"""
+        Compress(self.app)
         client = self.app.test_client()
         for algorithm in ('gzip', 'deflate', 'br', ''):
             headers = [('Accept-Encoding', algorithm)]
@@ -377,6 +381,17 @@ class StreamTests(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.is_streamed, True)
             self.assertEqual(self.file_size, len(response.data))
+
+    def test_disabled_stream(self):
+        """Test that stream compression can be disabled."""
+        Compress(self.app)
+        self.app.config["COMPRESS_STREAMS"] = True
+        client = self.app.test_client()
+        for algorithm in ('gzip', 'deflate', 'br'):
+            headers = [('Accept-Encoding', algorithm)]
+            response = client.get('/stream/large', headers=headers)
+            self.assertIn('Content-Encoding', response.headers)
+            self.assertGreater(self.file_size, len(response.data))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Thanks for the tool @alexprengere and others!

This pr is to close #33 and close #35 while still supporting folks how want to disable stream compression.

v 1.12 has also broken compression for my site's css and js.

To disable stream compression add `COMPRESS_STREAMS=False` to the flask config. 

The default (to make flask-compress continue working with the many existing live sites... is `COMPRESS_STREAMS=True`.

@gilad9366
@raphaeljolivet

I also added in tests to verify the changes. 