### PR TITLE
Add text/javascript mimetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Within your Flask application's settings you can provide the following settings 
 
 | Option | Description | Default |
 | ------ | ----------- | ------- |
-| `COMPRESS_MIMETYPES` | Set the list of mimetypes to compress here. | `[`<br>`'text/html',`<br>`'text/css',`<br>`'text/xml',`<br>`'application/json',`<br>`'application/javascript'`<br>`]` |
+| `COMPRESS_MIMETYPES` | Set the list of mimetypes to compress here. | `[`<br>`'application/javascript'`<br>`'application/json',`<br>`'text/css',`<br>`'text/html',`<br>`'text/javascript'`<br>`'text/xml'`<br>`]` |
 | `COMPRESS_LEVEL` | Specifies the gzip compression level. | `6` |
 | `COMPRESS_BR_LEVEL` | Specifies the Brotli compression level. Ranges from 0 to 11. | `4` |
 | `COMPRESS_BR_MODE` | For Brotli, the compression mode. The options are 0, 1, or 2. These correspond to "generic", "text" (for UTF-8 input), and "font" (for WOFF 2.0). | `0` |

--- a/flask_compress/flask_compress.py
+++ b/flask_compress/flask_compress.py
@@ -64,9 +64,14 @@ class Compress(object):
 
     def init_app(self, app):
         defaults = [
-            ('COMPRESS_MIMETYPES', ['text/html', 'text/css', 'text/xml',
-                                    'application/json',
-                                    'application/javascript']),
+            ('COMPRESS_MIMETYPES', [
+                'application/javascript',  # Obsolete (RFC 9239)
+                'application/json',
+                'text/css',
+                'text/html',
+                'text/javascript'
+                'text/xml',
+            ]),
             ('COMPRESS_LEVEL', 6),
             ('COMPRESS_BR_LEVEL', 4),
             ('COMPRESS_BR_MODE', 0),

--- a/flask_compress/flask_compress.py
+++ b/flask_compress/flask_compress.py
@@ -69,7 +69,7 @@ class Compress(object):
                 'application/json',
                 'text/css',
                 'text/html',
-                'text/javascript'
+                'text/javascript',
                 'text/xml',
             ]),
             ('COMPRESS_LEVEL', 6),


### PR DESCRIPTION
As of May 2022, MIME type `application/javascript` has become obsolete in favour of `text/javascript`. This may explain why one user has [reported](https://github.com/colour-science/flask-compress/issues/37) that their .js files were not being compressed.

The IETF has released [RFC 9239](https://www.rfc-editor.org/rfc/rfc9239.html#name-text-javascript) to explain the deprecation. The official list of MIME types posted by the [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml) shows that `text/javascript` is active while `application/javascript` is obsoleted.

In the backend if Flask is not given a MIME type, it will attempt to guess it. Here is a series of steps that Flask takes to guess the mimetype

1. The [send_file](https://github.com/pallets/flask/blob/9a4d370ea221b13d7fff5e2120007986c08f85fb/src/flask/helpers.py#L394) function takes an optional `mimetype` argument.
2. `send_file` calls [werkzeug.utils.send_file](https://github.com/pallets/werkzeug/blob/fae889d467a0a19385978f7e979234771a0eb10d/src/werkzeug/utils.py#L325) that will attempt to guess the MIME type  by calling [mimetypes.guess_type](https://github.com/pallets/werkzeug/blob/fae889d467a0a19385978f7e979234771a0eb10d/src/werkzeug/utils.py#L453) utilizing the cpython [mimetypes](https://github.com/python/cpython/blob/main/Lib/mimetypes.py) library
3. The mimetypes library by default limits to only the official types [registered with IANA](https://www.iana.org/assignments/media-types/media-types.xhtml). The .js file extension in this library maps to [text/javascript](https://github.com/python/cpython/blob/2b6f5c3483597abcb8422508aeffab04f500f568/Lib/mimetypes.py#L427) this is new.

For now users may include `app.config['COMPRESS_MIMETYPES'].append('text/javascript')` in their app until this PR is merged.

