### PR TITLE
Add a pre-commit file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+ci:
+  autoupdate_schedule: "quarterly"
+
+default_language_version:
+  python: "python3.12"
+
+exclude: "tests/templates/"
+
+repos:
+  - repo: "meta"
+    hooks:
+      - id: "check-hooks-apply"
+      - id: "check-useless-excludes"
+
+  - repo: "https://github.com/pre-commit/pre-commit-hooks"
+    rev: "v4.6.0"
+    hooks:
+      - id: "check-added-large-files"
+      - id: "check-merge-conflict"
+      - id: "check-yaml"
+      - id: "end-of-file-fixer"
+      - id: "mixed-line-ending"
+        args:
+          - "--fix=lf"
+      - id: "trailing-whitespace"
+
+  - repo: "https://github.com/python-jsonschema/check-jsonschema"
+    rev: "0.29.2"
+    hooks:
+      - id: "check-github-workflows"
+
+  - repo: "https://github.com/rhysd/actionlint"
+    rev: "v1.7.1"
+    hooks:
+      - id: "actionlint"

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ The preferred solution is to have a server (like [Nginx](http://wiki.nginx.org/M
 
 ## How it works
 
-Flask-Compress both adds the various headers required for a compressed response and compresses the response data. 
+Flask-Compress both adds the various headers required for a compressed response and compresses the response data.
 This makes serving compressed static files extremely easy.
 
 Internally, every time a request is made the extension will check if it matches one of the compressible MIME types
-and whether the client and the server use some common compression algorithm, and will automatically attach the 
+and whether the client and the server use some common compression algorithm, and will automatically attach the
 appropriate headers.
 
 To determine the compression algorithm, the `Accept-Encoding` request header is inspected, respecting the
-quality factor as described in [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding). 
+quality factor as described in [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding).
 If no requested compression algorithm is supported by the server, we don't compress the response. If, on the other
 hand, multiple suitable algorithms are found and are requested with the same quality factor, we choose the first one
-defined in the `COMPRESS_ALGORITHM` option (see below). 
+defined in the `COMPRESS_ALGORITHM` option (see below).
 
 
 ## Installation
@@ -98,8 +98,8 @@ def view():
 
 ### Cache example
 
-Flask-Compress can be integrated with caching mechanisms to serve compressed responses directly from the cache. This can significantly reduce server load and response times.  
-Here is an example of how to configure Flask-Compress with caching using Flask-Caching.  
+Flask-Compress can be integrated with caching mechanisms to serve compressed responses directly from the cache. This can significantly reduce server load and response times.
+Here is an example of how to configure Flask-Compress with caching using Flask-Caching.
 The example demonstrates how to create a simple cache instance with a 1-hour timeout, and use it to cache compressed responses for incoming requests.
 
 ```python


### PR DESCRIPTION
pre-commit.ci is enabled for this repo, but [all runs fail because the repo lacks a `.pre-commit-config.yaml` file](https://results.pre-commit.ci/repo/github/142751498).

This PR introduces the following changes:

* Add a preliminary `.pre-commit-config.yaml` file
* Run `pre-commit run -a` and commit the changes

If this PR is merged, I'll add more pre-commit hooks that can begin auto-resolving several items mentioned in #27, like switching to f-strings.