### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR introduces the following changes:

* Add a Dependabot config to auto-update GitHub action versions

Dependabot will check on a monthly basis whether new action versions (like `actions/checkout` or `actions/setup-python`) are available.

If so, it will submit a PR _at most once per month_ to keep the action versions updated. This frees developers from having to watch for, and update, action versions manually.