### PR TITLE
Add coverage reporting to the test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       run: pip install tox
     - name: Run tox
       # Run tox using the version of Python in `PATH`
-      run: tox -e py
+      run: tox -e py,coverage_report-ci
 
   dist:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,31 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "flask_compress/_version.py"
 write_to_template = "__version__ = \"{version}\"\n"
+
+
+# coverage
+# --------
+
+[tool.coverage.run]
+relative_files = true
+parallel = true
+branch = true
+source = [
+    "flask_compress",
+    "tests",
+]
+
+[tool.coverage.paths]
+source = [
+    "flask_compress",
+    "*/site-packages",
+]
+
+[tool.coverage.report]
+skip_covered = true
+fail_under = 94
+
+
+[tool.coverage.html]
+directory = "htmlcov/"
+skip_covered = false

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,45 @@
 [tox]
 skip_missing_interpreters = true
 envlist =
+    coverage_erase
+    # When modifying the list of CPython and PyPy versions to test here,
+    # be sure to update the "depends" configurations elsewhere in this file.
+    # This ensures that coverage is reported only after all tests have run.
     py{39, 310, 311, 312}
     pypy{39, 310}
+    coverage_report
+
+[testenv:coverage_erase]
+description = Erase coverage files
+deps =
+    coverage[toml]
+commands =
+    - coverage erase
 
 [testenv]
+description = Run the test suite
+depends =
+    py{39, 310, 311, 312},pypy{39, 310}: coverage_erase
 package = wheel
 wheel_build_env = .pkg
 deps =
+    coverage[toml]
     pytest
-commands = py.test {posargs}
+commands =
+    coverage run -m pytest {posargs}
+
+[testenv:coverage_report{,-ci}]
+description = Generate HTML and console coverage reports
+depends =
+    py{39, 310, 311, 312},pypy{39, 310}
+deps =
+    coverage[toml]
+commands_pre =
+    - coverage combine
+    # Only generate an HTML coverage report when running locally.
+    !ci: - coverage html
+commands =
+    coverage report
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This PR introduces the following changes

* Add coverage reporting to the test suite and in CI
* Fail the test suite if coverage falls below 94% (its current value for individual runs)
* Support parallel test suite execution locally (run `tox run-parallel`, or just `tox p`)

----

Key elements to add to the test suite:

Caching tests

> ![image](https://github.com/user-attachments/assets/ba0f8d45-e8dd-4e61-97f2-f0a2029d01bb)

ETag header generation

> ![image](https://github.com/user-attachments/assets/f49a96fc-0794-49a2-9ed2-07d1876df7d1)

Vary header generation

> ![image](https://github.com/user-attachments/assets/71eefe5f-8cb9-425c-9d97-eabd97899b3b)

