### PR TITLE
Support Python 3.14; switch to `pyzstd` for ZStandard support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,11 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
+          - '3.14'
           - 'pypy-3.9'
           - 'pypy-3.10'
+          - 'pypy-3.11'
         os: [ubuntu-latest] #, windows-latest, macos-latest]
 
     name: ${{ matrix.os }} - ${{ matrix.python-version }}
@@ -37,6 +40,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: pip install tox
     - name: Run tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `flask-compress` will be documented in this file.
 
+## Unreleased changes
+
+- Support, and test against, Python 3.14
+- Migrate from `zstandard` to `pyzstd`, which is now included in the Python 3.14 standard library
+
 ## 1.17 (2024-10-14)
 
 - Add support for Python 3.13 in tox and classifiers

--- a/flask_compress/compat.py
+++ b/flask_compress/compat.py
@@ -1,0 +1,26 @@
+# compression compatibility
+# -------------------------
+#
+# Use the Python 3.14 `compression` module if possible.
+# If unavailable, mimic the module structure for backwards compatibility.
+#
+# When Python 3.14 is the lowest supported version,
+# the `import compression.*` statements can move to `flask_compress.py`
+# and this try/except block can be removed from this file.
+try:
+    # Python >= 3.14
+    import compression.gzip
+    import compression.zlib
+    import compression.zstd
+except ModuleNotFoundError:
+    # Python <= 3.13
+    import gzip
+    import types
+    import zlib
+
+    import pyzstd
+
+    compression = types.SimpleNamespace()
+    compression.gzip = gzip
+    compression.zlib = zlib
+    compression.zstd = pyzstd

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ setup(
         "flask",
         "brotli; platform_python_implementation!='PyPy'",
         "brotlicffi; platform_python_implementation=='PyPy'",
-        "zstandard; platform_python_implementation!='PyPy'",
-        "zstandard[cffi]; platform_python_implementation=='PyPy'",
+        "pyzstd; python_version<'3.14'",
     ],
     setup_requires=[
         "setuptools_scm",
@@ -39,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/tests/templates/large.html
+++ b/tests/templates/large.html
@@ -9,5 +9,14 @@ consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non 
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </p>
+<p>
+Also,
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</p>
 </body>
 </html>

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist =
     # When modifying the list of CPython and PyPy versions to test here,
     # be sure to update the "depends" configurations elsewhere in this file.
     # This ensures that coverage is reported only after all tests have run.
-    py{39, 310, 311, 312, 313}
-    pypy{39, 310}
+    py{39, 310, 311, 312, 313, 314}
+    pypy{39, 310, 311}
     coverage_report
 
 [testenv:coverage_erase]
@@ -19,7 +19,7 @@ commands =
 [testenv]
 description = Run the test suite
 depends =
-    py{39, 310, 311, 312},pypy{39, 310}: coverage_erase
+    py{39, 310, 311, 312, 313, 314},pypy{39, 310, 311}: coverage_erase
 package = wheel
 wheel_build_env = .pkg
 deps =
@@ -32,7 +32,7 @@ commands =
 [testenv:coverage_report{,-ci}]
 description = Generate HTML and console coverage reports
 depends =
-    py{39, 310, 311, 312},pypy{39, 310}
+    py{39, 310, 311, 312, 313, 314},pypy{39, 310, 311}
 deps =
     coverage[toml]
 commands_pre =


### PR DESCRIPTION
Python 3.14 introduces a new `compression` module in the standard library, and has incorporated the `pyzstd` package into the standard library under the `compression.zstd` module.

This PR introduces Python 3.14 support and migrates to the `pyzstd` package for ongoing compatibility.

As a part of this change, a `compat` module has been added, which uses the Python 3.14 `compression` module if possible, and mimics the `compression` module if not. This ensures a clean, forward-looking interface so that the rest of the code can rely on a `compression.*` namespace.

Finally, some of the tox and CI Python versions have been updated to ensure consistent local and CI testing across CPython and PyPy versions.